### PR TITLE
upgrade aws-iot-device latest LTS version

### DIFF
--- a/aws-iot-device/Makefile
+++ b/aws-iot-device/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aws-iot-device
-PKG_VERSION:=202211.00
+PKG_VERSION:=202412.00
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL=https://github.com/dedesignworks/aws-iot-device-sdk-embedded-C.git
-PKG_SOURCE_VERSION:=7f8551bcaa8d811c44473db7755965a5316e3a7d
+PKG_SOURCE_URL=git@github.com:aws/aws-iot-device-sdk-embedded-C.git
+PKG_SOURCE_VERSION:=202412.00
 CMAKE_INSTALL:=1
 PKG_INSTALL:=1
 

--- a/aws-iot-device/Makefile
+++ b/aws-iot-device/Makefile
@@ -45,16 +45,17 @@ define Build/Configure
 	echo 'install(TARGETS sigv4 DESTINATION "$$$${CSDK_LIB_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'install(DIRECTORY "$$$${CMAKE_CURRENT_LIST_DIR}/libraries/aws/sigv4-for-aws-iot-embedded-sdk/source/include/" DESTINATION "$$$${CSDK_HEADER_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'install(FILES sigv4_config/sigv4_config.h DESTINATION "$$$${CSDK_HEADER_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/CMakeLists.txt
+	echo 'install(TARGETS tinycbor mbedtls DESTINATION "$$$${CSDK_LIB_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/libraries/3rdparty/CMakeLists.txt
 	$(call Build/Configure/Default)
 endef
 
 define Package/aws-iot-device/install
-	$(INSTALL_DIR) $(1)/usr/lib/aws
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/aws/lib*.so* $(1)/usr/lib/aws/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/lib/aws
+	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
 endef

--- a/aws-iot-device/Makefile
+++ b/aws-iot-device/Makefile
@@ -33,18 +33,23 @@ CMAKE_OPTIONS+= \
 	-DINSTALL_TO_SYSTEM:bool=ON \
 	-DCMAKE_SKIP_RPATH=OFF \
 	-DCMAKE_INSTALL_RPATH="/usr/lib/aws" \
-	-DBUILD_CLONE_SUBMODULES:bool=ON
+	-DBUILD_CLONE_SUBMODULES:bool=ON \
+	-DMQTT_CUSTOM_CONFIG_DIR=$(PKG_BUILD_DIR)/mqtt_config
 
 define Build/Configure
 	# Copy sigv4_config.h from files directory
 	mkdir -p $(PKG_BUILD_DIR)/sigv4_config
 	cp ./files/sigv4_config.h $(PKG_BUILD_DIR)/sigv4_config/
+	# Copy core_mqtt_config.h from files directory
+	mkdir -p $(PKG_BUILD_DIR)/mqtt_config
+	cp ./files/core_mqtt_config.h $(PKG_BUILD_DIR)/mqtt_config/
 	echo 'include(libraries/aws/sigv4-for-aws-iot-embedded-sdk/sigv4FilePaths.cmake)' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'add_library(sigv4 $$$${SIGV4_SOURCES})' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'target_include_directories(sigv4 PUBLIC $$$${SIGV4_INCLUDE_PUBLIC_DIRS} $$$${CMAKE_CURRENT_SOURCE_DIR}/sigv4_config)' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'install(TARGETS sigv4 DESTINATION "$$$${CSDK_LIB_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'install(DIRECTORY "$$$${CMAKE_CURRENT_LIST_DIR}/libraries/aws/sigv4-for-aws-iot-embedded-sdk/source/include/" DESTINATION "$$$${CSDK_HEADER_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'install(FILES sigv4_config/sigv4_config.h DESTINATION "$$$${CSDK_HEADER_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/CMakeLists.txt
+	echo 'target_include_directories(aws_iot_mqtt BEFORE PUBLIC $$$${CMAKE_CURRENT_SOURCE_DIR}/mqtt_config $$$${CMAKE_CURRENT_SOURCE_DIR}/demos/logging-stack)' >> $(PKG_BUILD_DIR)/CMakeLists.txt
 	echo 'install(TARGETS tinycbor mbedtls DESTINATION "$$$${CSDK_LIB_INSTALL_PATH}")' >> $(PKG_BUILD_DIR)/libraries/3rdparty/CMakeLists.txt
 	$(call Build/Configure/Default)
 endef

--- a/aws-iot-device/files/core_mqtt_config.h
+++ b/aws-iot-device/files/core_mqtt_config.h
@@ -76,6 +76,16 @@
 #define MQTT_PINGRESP_TIMEOUT_MS      ( 15000U )
 
 /**
+ * @brief Maximum number of milliseconds of TX inactivity before initiating a PINGREQ.
+ *
+ * coreMQTT uses this as a cap on keepAliveIntervalSec: if PACKET_TX_TIMEOUT_MS is
+ * less than the configured keep_alive_interval_seconds (converted to ms), the
+ * effective PINGREQ interval is capped to PACKET_TX_TIMEOUT_MS. Set this to at
+ * least as large as the maximum keep_alive_interval_seconds value you intend to use.
+ */
+#define PACKET_TX_TIMEOUT_MS          ( 300000U ) /* 5 minutes */
+
+/**
  * @brief Maximum number of milliseconds of RX inactivity before initiating a PINGREQ.
  *
  * Set to UINT32_MAX to disable the RX-based keep-alive trigger. coreMQTT never

--- a/aws-iot-device/files/core_mqtt_config.h
+++ b/aws-iot-device/files/core_mqtt_config.h
@@ -1,0 +1,96 @@
+/*
+ * AWS IoT Device SDK for Embedded C 202211.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CORE_MQTT_CONFIG_H_
+#define CORE_MQTT_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Logging related header files are required to be included in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define LIBRARY_LOG_NAME and  LIBRARY_LOG_LEVEL.
+ * 3. Include the header file "logging_stack.h".
+ */
+
+/* Include header that defines log levels. */
+#include "logging_levels.h"
+
+/* Configure name and log level for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME     "MQTT"
+#endif
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+/**
+ * @brief Determines the maximum number of MQTT PUBLISH messages, pending
+ * acknowledgement at a time, that are supported for incoming and outgoing
+ * direction of messages, separately.
+ *
+ * QoS 1 and 2 MQTT PUBLISHes require acknowledgement from the server before
+ * they can be completed. While they are awaiting the acknowledgement, the
+ * client must maintain information about their state. The value of this
+ * macro sets the limit on how many simultaneous PUBLISH states an MQTT
+ * context maintains, separately, for both incoming and outgoing direction of
+ * PUBLISHes.
+ *
+ * @note The MQTT context maintains separate state records for outgoing
+ * and incoming PUBLISHes, and thus, 2 * MQTT_STATE_ARRAY_MAX_COUNT amount
+ * of memory is statically allocated for the state records.
+ */
+#define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
+
+/**
+ * @brief Number of milliseconds to wait for a ping response to a ping
+ * request as part of the keep-alive mechanism.
+ *
+ * If a ping response is not received before this timeout, then
+ * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
+ */
+#define MQTT_PINGRESP_TIMEOUT_MS      ( 15000U )
+
+/**
+ * @brief Maximum number of milliseconds of RX inactivity before initiating a PINGREQ.
+ *
+ * Set to UINT32_MAX to disable the RX-based keep-alive trigger. coreMQTT never
+ * updates MQTTContext_t.lastPacketRxTime (it remains 0 after MQTT_Init), so
+ * calculateElapsedTime(now, 0) always equals the current monotonic time in ms,
+ * which exceeds the default PACKET_RX_TIMEOUT_MS (30000ms) immediately after
+ * ~30s of system uptime. This causes a PINGREQ to be sent on every
+ * handleKeepAlive() call regardless of the configured keep_alive_interval_seconds,
+ * making the effective PINGREQ interval equal to transport_receive_timeout_ms
+ * rather than the intended keep-alive interval.
+ *
+ * With PACKET_RX_TIMEOUT_MS = UINT32_MAX the RX path never fires (would require
+ * ~49.7 days of uptime), leaving the TX-based path (keepAliveIntervalSec) in
+ * sole control of PINGREQ timing.
+ */
+#define PACKET_RX_TIMEOUT_MS          ( 0xFFFFFFFFU )
+
+#endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/aws-iot-device/files/core_mqtt_config.h
+++ b/aws-iot-device/files/core_mqtt_config.h
@@ -88,19 +88,11 @@
 /**
  * @brief Maximum number of milliseconds of RX inactivity before initiating a PINGREQ.
  *
- * Set to UINT32_MAX to disable the RX-based keep-alive trigger. coreMQTT never
- * updates MQTTContext_t.lastPacketRxTime (it remains 0 after MQTT_Init), so
- * calculateElapsedTime(now, 0) always equals the current monotonic time in ms,
- * which exceeds the default PACKET_RX_TIMEOUT_MS (30000ms) immediately after
- * ~30s of system uptime. This causes a PINGREQ to be sent on every
- * handleKeepAlive() call regardless of the configured keep_alive_interval_seconds,
- * making the effective PINGREQ interval equal to transport_receive_timeout_ms
- * rather than the intended keep-alive interval.
- *
- * With PACKET_RX_TIMEOUT_MS = UINT32_MAX the RX path never fires (would require
- * ~49.7 days of uptime), leaving the TX-based path (keepAliveIntervalSec) in
- * sole control of PINGREQ timing.
+ * coreMQTT uses this as a cap on keepAliveIntervalSec: if PACKET_RX_TIMEOUT_MS is
+ * less than the configured keep_alive_interval_seconds (converted to ms), the
+ * effective PINGREQ interval is capped to PACKET_RX_TIMEOUT_MS. Set this to at
+ * least as large as the maximum keep_alive_interval_seconds value you intend to use.
  */
-#define PACKET_RX_TIMEOUT_MS          ( 0xFFFFFFFFU )
+#define PACKET_RX_TIMEOUT_MS          ( 300000U ) /* 5 minutes */
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */


### PR DESCRIPTION
upgrades `aws-iot-device-sdk-embedded-C` library to latest released LTS version, and eliminates the need for a forked repository

after merge: archive https://github.com/dedesignworks/aws-iot-device-sdk-embedded-C

fixes: https://github.com/dedesignworks/openwrt-gateway/issues/105
related: https://github.com/dedesignworks/openwrt-gateway/issues/102